### PR TITLE
Update caller skip frame count of zerolog as 3

### DIFF
--- a/overlogger.go
+++ b/overlogger.go
@@ -34,6 +34,7 @@ func NewDefault() *Overlog {
 	zerolog.LevelFieldMarshalFunc = UppercaseLevelEncoder()
 	zerolog.CallerMarshalFunc = ShortCallerEncoder()
 	zerolog.CallerFieldName = "source"
+	zerolog.CallerSkipFrameCount = 3
 
 	overLogger = &Overlog{
 		log: &log.Logger,


### PR DESCRIPTION
When using overlog as library, default logger's source is always like "overlog/overlogger:70". This is about runtime.Caller() in zerolog library. And there is a variable that we can set to skip X frames to find the actual caller.
Update this variable in order to make caller the actual service instead of overlog.
It basically skips 3 frames instead of 2 from trace to find the actual caller.